### PR TITLE
FeatureManager

### DIFF
--- a/app/models/jane/feature.rb
+++ b/app/models/jane/feature.rb
@@ -5,7 +5,7 @@ module Jane
 
     validates :name, :identifier, presence: true, uniqueness: true
 
-    before_create :build_identifier
+    before_validation :build_identifier
 
     private
 

--- a/app/models/jane/feature.rb
+++ b/app/models/jane/feature.rb
@@ -3,7 +3,7 @@ module Jane
     has_many :feature_assignments, dependent: :destroy
     has_many :assignables, through: :feature_assignments, source: :assignable
 
-    validates :name, :identifier, uniqueness: true
+    validates :name, :identifier, presence: true, uniqueness: true
 
     before_create :build_identifier
 

--- a/app/models/jane/feature.rb
+++ b/app/models/jane/feature.rb
@@ -3,12 +3,14 @@ module Jane
     has_many :feature_assignments, dependent: :destroy
     has_many :assignables, through: :feature_assignments, source: :assignable
 
+    validates :name, :identifier, uniqueness: true
+
     before_create :build_identifier
 
     private
 
     def build_identifier
-      self.identifier = self.name.snakecase
+      self.identifier = self.name.underscore.parameterize(separator: '_')
     end
   end
 end

--- a/lib/generators/jane/templates/create_features.rb
+++ b/lib/generators/jane/templates/create_features.rb
@@ -7,5 +7,6 @@ class CreateJaneFeatures < ActiveRecord::Migration[8.0]
       t.timestamps
     end
     add_index :jane_features, :name, unique: true
+    add_index :jane_features, :identifier, unique: true
   end
 end

--- a/lib/jane.rb
+++ b/lib/jane.rb
@@ -3,8 +3,12 @@
 require "jane/version"
 require "jane/engine"
 require "jane/featureable"
+require "jane/feature_manager"
 
 module Jane
   class Error < StandardError; end
-  # Your code goes here...
+  
+  def self.for(assignable)
+    FeatureManager.new(assignable)
+  end
 end

--- a/lib/jane/feature_manager.rb
+++ b/lib/jane/feature_manager.rb
@@ -1,0 +1,28 @@
+# lib/jane/feature_manager.rb
+module Jane
+  class FeatureManager
+    def initialize(assignable)
+      @assignable = assignable
+    end
+
+    def enable(feature)
+      assignable.add_feature(feature)
+    end
+
+    def disable(feature)
+      assignable.remove_feature(feature)
+    end
+
+    def clear
+      assignable.clear_features
+    end
+
+    def has?(feature)
+      assignable.has_feature?(feature)
+    end
+
+    private
+
+    attr_reader :assignable
+  end
+end

--- a/lib/jane/featureable.rb
+++ b/lib/jane/featureable.rb
@@ -7,18 +7,18 @@ module Jane
       has_many :features, through: :feature_assignments, class_name: "Jane::Feature"
     end
 
-    def has_feature?(name)
-      features.exists?(name: name)
+    def has_feature?(identifier)
+      features.exists?(identifier: identifier.to_s)
     end
 
     def add_feature(feature)
       feature = find_feature!(feature)
-      features << feature unless has_feature?(feature.name)
+      features << feature unless has_feature?(feature.identifier)
     end
 
     def remove_feature(feature)
       feature = find_feature!(feature)
-      features.destroy(feature) if has_feature?(feature.name)
+      features.destroy(feature) if has_feature?(feature.identifier)
     end
 
     def clear_features
@@ -30,7 +30,7 @@ module Jane
     def find_feature!(feature)
       return feature if feature.is_a?(Jane::Feature)
 
-      Jane::Feature.find_by!(name: feature.to_s)
+      Jane::Feature.find_by!(identifier: feature.to_s)
     end
   end
 end


### PR DESCRIPTION
# Context
It is possible to use the `Jane::Featureable` to ask if the use already have a feature, to add one, to remove and so one, by doing something like:
```ruby
user.has_feature?(:super_powers) # Checks if user has a single feature
user.add_feature(:super_powers) # Adds a feature to user
user.remove_feature(:super_powers) # Removes a feature from an user
user.clear_features # Clears all features from an user
```

Now, there are some use cases that due to the fact of feature relation being generic, we need to add a `FeatureManager` to make it easier to work with different types of models/tables/data.

# Resolution
Added a `FeatureManager` to make use easier by just doing a:
```ruby
Jane.for(assignable).has?(:super_powers) # Checks if assignable (user || account || anything) has a single feature
Jane.for(assignable).enable(:super_powers) # Enables/adds a feature to an assignable
Jane.for(assignable).disable(:super_powers) # Disables/removes a feature from an assignable
Jane.for(assignable).clear # Clears all features from an assignable
```

The require is done at: https://github.com/azeveco/Jane/blob/e9f0fd97e70527837d3a6c823a217f8334b2ce88/lib/jane.rb#L6

While the call to the `FeatureManager` happens here: https://github.com/azeveco/Jane/blob/e9f0fd97e70527837d3a6c823a217f8334b2ce88/lib/jane.rb#L11-L13

I've also decided to use this PR to add:
* Search for `Feature` by using the `identifier`
* Validating presence and uniqueness of both `name` and `identifier`
* Changing the `build_identifier` called in the `before_create` callback of the `Jane::Feature` to be called on `before_validation`
* Fixing an error with building the identifier itself (it wasnt being snake_cased)
* Adding an index by `identifier`