### PR TITLE
FeatureQuery

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -15,6 +15,8 @@ def important
   puts "When using code blocks, make sure you define the language, in this case Ruby"
   puts "Why? Well... to make sure that beautiful syntax highlight will show up"
 end
+
+return important if you_love_community?
 ```
 
 # Impacted processes/locations

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,6 +10,13 @@ Describe how you achieved whatever you've done.
 
 You can put code snippets inside code blocks, you can link to lines from files of this PR by using permalink and so on.
 
+```ruby
+def important
+  puts "When using code blocks, make sure you define the language, in this case Ruby"
+  puts "Why? Well... to make sure that beautiful syntax highlight will show up"
+end
+```
+
 # Impacted processes/locations
 Make sure you write here which processes or locations were impacted by this PR.
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,22 @@
+# Context
+Explain here what led you to create this Pull Request.
+
+Make sure you also specify the type of the PR with tags and here.
+
+You can link issues, articles and more.
+
+# Resolution
+Describe how you achieved whatever you've done.
+
+You can put code snippets inside code blocks, you can link to lines from files of this PR by using permalink and so on.
+
+# Impacted processes/locations
+Make sure you write here which processes or locations were impacted by this PR.
+
+Example:
+* `FeatureQuery/for_type`: impacted because it changed its behaviour
+* `create_features` migration: added a new column
+* `install`: changed the behaviour of the `rails generate jane:install` command thanks to something
+
+# References
+You can link issues and articles on the context, resolution and more to strengthen the reason for your decisions, but this is a dedicated area just for that.

--- a/app/models/jane/feature.rb
+++ b/app/models/jane/feature.rb
@@ -7,14 +7,18 @@ module Jane
 
     before_validation :build_identifier
 
-    scope :for_group, ->(group) { where(group: group) }
+    scope :for_group, ->(group) { where(group:) }
     scope :without_group, -> { where(group: nil) }
 
-    scope :for_environment, ->(env) { where(environment: env) }
+    scope :for_environment, ->(environment) { where(environment:) }
     scope :without_environment, -> { where(environment: nil) }
 
-    scope :for_tenant, ->(tenant_id) { where(tenant: tenant_id) }
-    scope :without_tenant, -> { where(tenant: nil) }
+    scope :for_tenant, ->(tenant_id) { where(tenant_id:) }
+    scope :without_tenant, -> { where(tenant_id: nil) }
+
+    scope :inactive, -> { where(status: :inactive) }
+    scope :active, -> { where(status: :active) }
+    scope :with_status, ->(status) { where(status:) }
 
     validates :name, :identifier, presence: true, uniqueness: true
 

--- a/app/models/jane/feature.rb
+++ b/app/models/jane/feature.rb
@@ -1,11 +1,22 @@
 module Jane
   class Feature < ApplicationRecord
+    enum :status, [ :inactive, :active ]
+    
     has_many :feature_assignments, dependent: :destroy
     has_many :assignables, through: :feature_assignments, source: :assignable
 
-    validates :name, :identifier, presence: true, uniqueness: true
-
     before_validation :build_identifier
+
+    scope :for_group, ->(group) { where(group: group) }
+    scope :without_group, -> { where(group: nil) }
+
+    scope :for_environment, ->(env) { where(environment: env) }
+    scope :without_environment, -> { where(environment: nil) }
+
+    scope :for_tenant, ->(tenant_id) { where(tenant: tenant_id) }
+    scope :without_tenant, -> { where(tenant: nil) }
+
+    validates :name, :identifier, presence: true, uniqueness: true
 
     private
 

--- a/app/models/jane/feature_assignment.rb
+++ b/app/models/jane/feature_assignment.rb
@@ -2,5 +2,7 @@ module Jane
   class FeatureAssignment < ApplicationRecord
     belongs_to :feature, class_name: "Jane::Feature"
     belongs_to :assignable, polymorphic: true
+
+    scope :for_type, ->(klass) { where(assignable_type: klass.to_s) }
   end
 end

--- a/lib/generators/jane/templates/create_features.rb
+++ b/lib/generators/jane/templates/create_features.rb
@@ -4,6 +4,10 @@ class CreateJaneFeatures < ActiveRecord::Migration[8.0]
       t.string :name, null: false
       t.string :identifier, null: false
       t.string :description
+      t.string :tenant
+      t.string :group
+      t.string :environment
+      t.integer :status, default: 0
       t.timestamps
     end
     add_index :jane_features, :name, unique: true

--- a/lib/jane.rb
+++ b/lib/jane.rb
@@ -25,16 +25,16 @@ module Jane
     FeatureQuery.new.for_type(klass)
   end
   
-  def self.for_group(klass)
-    FeatureQuery.new.for_group(klass)
+  def self.for_group(group)
+    FeatureQuery.new.for_group(group)
   end
 
   def self.without_group
     FeatureQuery.new.without_group
   end
 
-  def self.for_environment(env)
-    FeatureQuery.new.for_environment(env)
+  def self.for_environment(environment)
+    FeatureQuery.new.for_environment(environment)
   end
 
   def self.without_environment
@@ -51,6 +51,10 @@ module Jane
 
   def self.for_filters(filters: {})
     FeatureQuery.new.for_filters(filters)
+  end
+
+  def self.with_status(status)
+    FeatureQuery.new.with_status(status)
   end
 
   class <<self

--- a/lib/jane.rb
+++ b/lib/jane.rb
@@ -4,11 +4,60 @@ require "jane/version"
 require "jane/engine"
 require "jane/featureable"
 require "jane/feature_manager"
+require "jane/feature_query"
 
 module Jane
   class Error < StandardError; end
+
+  def self.feature(identifier)
+    FeatureQuery.new.feature(identifier)
+  end
+
+  def self.destroy_feature(identifier)
+    FeatureQuery.new.destroy_feature(identifier)
+  end
   
   def self.for(assignable)
     FeatureManager.new(assignable)
+  end
+  
+  def self.for_type(klass)
+    FeatureQuery.new.for_type(klass)
+  end
+  
+  def self.for_group(klass)
+    FeatureQuery.new.for_group(klass)
+  end
+
+  def self.without_group
+    FeatureQuery.new.without_group
+  end
+
+  def self.for_environment(env)
+    FeatureQuery.new.for_environment(env)
+  end
+
+  def self.without_environment
+    FeatureQuery.new.without_environment
+  end
+
+  def self.for_tenant(tenant_id)
+    FeatureQuery.new.for_tenant(tenant_id)
+  end
+
+  def self.without_tenant
+    FeatureQuery.new.without_tenant
+  end
+
+  def self.for_filters(filters: {})
+    FeatureQuery.new.for_filters(filters)
+  end
+
+  class <<self
+    alias_method :for_role, :for_group
+    alias_method :without_role, :without_group
+
+    alias_method :for_env, :for_environment
+    alias_method :without_env, :without_environment
   end
 end

--- a/lib/jane/feature_manager.rb
+++ b/lib/jane/feature_manager.rb
@@ -1,4 +1,3 @@
-# lib/jane/feature_manager.rb
 module Jane
   class FeatureManager
     def initialize(assignable)

--- a/lib/jane/feature_query.rb
+++ b/lib/jane/feature_query.rb
@@ -18,18 +18,18 @@ module Jane
     end
     alias :for_role :for_group
 
-    def without_group(group)
-      Jane::Feature.without_group(group)
+    def without_group
+      Jane::Feature.without_group
     end
     alias :without_role :without_group
 
-    def for_environment(env)
-      Jane::Feature.for_environment(env)
+    def for_environment(environment)
+      Jane::Feature.for_environment(environment)
     end
     alias :for_env :for_environment
 
-    def without_environment(env)
-      Jane::Feature.without_environment(env)
+    def without_environment
+      Jane::Feature.without_environment
     end
     alias :without_env :without_environment
 
@@ -37,8 +37,8 @@ module Jane
       Jane::Feature.for_tenant(tenant_id)
     end
 
-    def without_tenant(tenant_id)
-      Jane::Feature.without_tenant(tenant_id)
+    def without_tenant
+      Jane::Feature.without_tenant
     end
 
     def for_filters(filters)
@@ -46,6 +46,10 @@ module Jane
         .for_group(filters[:group] || filters[:role])
         .for_environment(filters[:environment] || filters[:env])
         .for_tenant(filters[:tenant_id])
+    end
+
+    def with_status(status)
+      Jane::Feature.with_status(status)
     end
   end
 end

--- a/lib/jane/feature_query.rb
+++ b/lib/jane/feature_query.rb
@@ -1,0 +1,51 @@
+module Jane
+  class FeatureQuery
+    def feature(identifier)
+      Jane::Feature.find_by!(identifier:)
+    end
+
+    def destroy_feature(identifier)
+      feature = Jane::Feature.find_by!(identifier:)
+      feature&.destroy
+    end
+
+    def for_type(klass)
+      Jane::FeatureAssignment.for_type(klass)
+    end
+
+    def for_group(group)
+      Jane::Feature.for_group(group)
+    end
+    alias :for_role :for_group
+
+    def without_group(group)
+      Jane::Feature.without_group(group)
+    end
+    alias :without_role :without_group
+
+    def for_environment(env)
+      Jane::Feature.for_environment(env)
+    end
+    alias :for_env :for_environment
+
+    def without_environment(env)
+      Jane::Feature.without_environment(env)
+    end
+    alias :without_env :without_environment
+
+    def for_tenant(tenant_id)
+      Jane::Feature.for_tenant(tenant_id)
+    end
+
+    def without_tenant(tenant_id)
+      Jane::Feature.without_tenant(tenant_id)
+    end
+
+    def for_filters(filters)
+      Jane::Feature
+        .for_group(filters[:group] || filters[:role])
+        .for_environment(filters[:environment] || filters[:env])
+        .for_tenant(filters[:tenant_id])
+    end
+  end
+end


### PR DESCRIPTION
# Context
After the [`FeatureManager #1`](https://github.com/azeveco/Jane/pull/1) PR, it became clear that we need a few other things to improve the experience, like different ways of querying data.

This PR does basically that and also adds a PR template 🎉 

# Resolution
Even though we have many new lines, everything is basically a copy & paste. But hey, nothing wrong with that. We all start somewhere, right?

* Added new columns to `Jane::Feature` to make users of **Jane** to filter features by `group`, `environment`, `tenant` and `status`
* The `status` holds the `inactive` or `active` values. This status is not to define if a assignable either has ou hasn't a feature, but to decide if this feature is available in the entire system
  * It's up to you to define how you will implement it. Is it disabled? Then this feature is likely unrelease. Or maybe if it is disabled, you can see the flag to active to an assignable but can't change the values? Again, it's up to you!
* Added `scopes` to `Jane::Feature` to use the `FeatureQuery` class to help query data. `nil` is an option here, by the way
* Added a single `scope` to `Jane::FeatureAssignment` to get all features enabled to a type of assignable
* Added methods to find and destroy a feature
* Added a PR template 🎉 

Here's to you how somethings are working right now:
```ruby
# To query Jane::Features from a specific group (the same applies to environment and tenant)
Jane::Feature.where(group: :dev)
Jane::Feature.for_group(:dev)
Jane.for_group(:dev)
Jane.for_role(:dev)
Jane.for_filters(filters: {group: :dev})
Jane.for_filters(filter: {role: :dev}

# To query Jane::Features by status (the same applies to inactive)
Jane::Feature.where(status: :active)
Jane::Feature.active
Jane.with_status(:active)
```

PS.: Both `group` and `environment` have aliases that can be used outside of `Jane::Feature`. If you want to query `Jane::Feature` directly, use only the default name.
* `group` can be written as `role` outside of `Jane::Feature`
* `environment` can be written as `env` out side of `Jane::Feature`

# Impacted processes/locations
* `FeatureQuery`: the new file to query data
* `lib/jane.rb`: this shouldn't break anything because only new methods were added and the old are untouched
* `Jane::Features`: new columns and scopes were added
* `Jane::FeatureAssignment`: scope were added

# References
* None
* My brain 🧠 
* Not a good start to documentation, I know. Sorry.